### PR TITLE
specify synctex file to patch

### DIFF
--- a/R/patchSynctex.R
+++ b/R/patchSynctex.R
@@ -1,5 +1,5 @@
 patchSynctex <-
-function (nwfile, verbose=FALSE, ...){
+function (nwfile, syncfile, verbose=FALSE, ...){
     ## require(tools)
     f=paste0(tools::file_path_sans_ext(nwfile), "-concordance.tex")
     if (!file.exists(f)) 
@@ -26,10 +26,14 @@ function (nwfile, verbose=FALSE, ...){
         rleO$lengths=as.integer(rleValues[seq(1,length(rleValues),2)]);
         diffs=inverse.rle(rleO);
         mapping_=c(startLine,startLine+cumsum(diffs[-1]));
-        
-        basename <- tools::file_path_sans_ext(rnwF);		
-        syncF = paste0(basename,".synctex");
-        
+
+        basename <- tools::file_path_sans_ext(rnwF);
+        if(missing(syncfile)) {
+          syncF = paste0(basename,".synctex");
+        } else {
+          syncF = paste0(syncfile,".synctex");
+        }
+
         compressed <- FALSE
         if (file.exists(syncF)) {
             sf=file(syncF);


### PR DESCRIPTION
resolves #3 

This is one possible solution. I am not sure if it is the best solution. However, I have tested this, and it successfully syncs (both ways) between the source file (main.Rnw and external.Rnw) and main.pdf file in Atom with thomasjo/atom-latex#251.

``` R
patchSynctex('main', syncfile='main');
patchSynctex('external', syncfile='main');
```

syncfile is an optional argument so that existing calls to this function still behave the same.
